### PR TITLE
Force autoSale/capture when doing a purchase request

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -44,6 +44,7 @@ class PurchaseRequest extends AbstractRequest
         $data['currencyCode'] = $this->getCurrency();
         $data['amount'] = $this->getAmountInteger();
         $data['redirectUrl'] = $this->getReturnUrl();
+        $data['autoSale'] = 'true';
 
         if ($this->getCard()) {
             $data['customerFirstName'] = $this->getCard()->getFirstName();


### PR DESCRIPTION
It's a small change but some account have authorize as the default behaviour and using PurchaseRequest will not capture the payment right away, but it will only authorize.

This change forces the expected behaviour of the PurchaseRequest.
