### PR TITLE
Adds TransactionReconRef for reconciliation

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -50,6 +50,7 @@ class PurchaseRequest extends AbstractRequest
         $data['merchantId'] = $this->getMerchantId();
         $data['token'] = $this->getPassword();
         $data['serviceType'] = 'B';
+        $data['transactionReconRef'] = $this->getTransactionId();
         $data['orderNumber'] = $this->getTransactionId();
         $data['currencyCode'] = $this->getCurrency();
         $data['amount'] = $this->getAmountInteger();

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -99,9 +99,6 @@ class GatewayTest extends GatewayTestCase
         $this->assertFalse($response->isSuccessful());
         $this->assertFalse($response->isRedirect());
         $this->assertNull($response->getTransactionReference());
-
-        var_dump($response->getMessage());
-
         $this->assertSame('Unable to find transaction', $response->getMessage());
     }
 

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -47,6 +47,7 @@ class PurchaseRequestTest extends TestCase
             'merchantId' => 'MERCH-123',
             'token' => 'PASSWORD-123',
             'serviceType' => 'B',
+            'transactionReconRef' => 'ABC-123',
             'orderNumber' => 'ABC-123',
             'currencyCode' => 'USD',
             'amount' => 123,


### PR DESCRIPTION
Some acquirers use TransactonReconRef instead of OrderNumber for reconciliation.
Removed var_dump from a test.